### PR TITLE
Node 4.0 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "author": "Carlos Guerreiro <carlos@perceptiveconstructs.com (http://perceptiveconstructs.com)",
   "dependencies": {"rdb-parser": "jmealo/rdb-parser", "bufferjs": "1.1.0"},
-  "devDependencies": {"rawhash": "0.1.6"},
   "licenses": [
     {
       "type": "MIT",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=0.4.0 <0.9.0"
   },
   "author": "Carlos Guerreiro <carlos@perceptiveconstructs.com (http://perceptiveconstructs.com)",
-  "dependencies": {"rdb-parser": "0.1.5", "bufferjs": "1.1.0"},
+  "dependencies": {"rdb-parser": "jmealo/rdb-parser", "bufferjs": "1.1.0"},
   "devDependencies": {"rawhash": "0.1.6"},
   "licenses": [
     {


### PR DESCRIPTION
This is a bit of a heads up PR. However, merging it will make it Node.js compatible.

Right now, I have it pointed at my Node 4.0 compatible rdb-parser, to get my Node 4.0 compatible node-lzf.

Removing rawhash as a dev dependency allows `npm install` to work.
